### PR TITLE
no more memory grow with Tracy

### DIFF
--- a/memory-leak-engine/include/Macros.h
+++ b/memory-leak-engine/include/Macros.h
@@ -53,6 +53,8 @@ namespace LoggingMacros {
 #undef TRACY_ENABLE
 #endif
 
+#define TRACY_ON_DEMAND
+
 #include "common/TracyColor.hpp"
 #include "glad/glad.h"
 #include "tracy/Tracy.hpp"


### PR DESCRIPTION
By default Tracy is constantly storing the profiling data in memory before you connect to it with Tracy.exe.
With time, the amount of data allocated can reach gigabytes of magnitude.
According to Tracy's documentation (2.1.2 On-demand profiling), this behaviour can be turned off with TRACY_ON_DEMAND macro.

A caveat is that this incurs a bit of a performance hit.

I couldn't get this project to build, so I'm not sure 100% sure if this fixes the issue. (Although it worked for the Silence engine.)

In case it doesn't work with just a define macro in header file (For Silence it didn't, we had to add `on-demand` to vcpkg entry), try adding TRACY_ON_DEMAND into the CPMAddPackage command [(like here)](https://github.com/LandSandBoat/server/blob/f0dc5d75172ac5393db02d8083789f1af699601e/ext/CMakeLists.txt#L29).